### PR TITLE
🔨 refactor(group_chat_member_added.go): change return type from point…

### DIFF
--- a/pkg/command/domain/events/group_chat_member_added.go
+++ b/pkg/command/domain/events/group_chat_member_added.go
@@ -17,15 +17,15 @@ type GroupChatMemberAdded struct {
 	occurredAt  uint64
 }
 
-func NewGroupChatMemberAdded(aggregateId models.GroupChatId, member models.Member, seqNr uint64, executorId models.UserAccountId) *GroupChatMemberAdded {
+func NewGroupChatMemberAdded(aggregateId models.GroupChatId, member models.Member, seqNr uint64, executorId models.UserAccountId) GroupChatMemberAdded {
 	id := ulid.Make().String()
 	now := time.Now()
 	occurredAt := uint64(now.UnixNano() / 1e6)
-	return &GroupChatMemberAdded{id, aggregateId, member, seqNr, executorId, occurredAt}
+	return GroupChatMemberAdded{id, aggregateId, member, seqNr, executorId, occurredAt}
 }
 
-func NewGroupChatMemberAddedFrom(id string, aggregateId models.GroupChatId, member models.Member, seqNr uint64, executorId models.UserAccountId, occurredAt uint64) *GroupChatMemberAdded {
-	return &GroupChatMemberAdded{id, aggregateId, member, seqNr, executorId, occurredAt}
+func NewGroupChatMemberAddedFrom(id string, aggregateId models.GroupChatId, member models.Member, seqNr uint64, executorId models.UserAccountId, occurredAt uint64) GroupChatMemberAdded {
+	return GroupChatMemberAdded{id, aggregateId, member, seqNr, executorId, occurredAt}
 }
 
 func (g *GroupChatMemberAdded) ToJSON() map[string]interface{} {


### PR DESCRIPTION
…er to value in NewGroupChatMemberAdded and NewGroupChatMemberAddedFrom functions to avoid potential null pointer exceptions and improve code safety